### PR TITLE
Add splash and instructions screens

### DIFF
--- a/game.js
+++ b/game.js
@@ -78,4 +78,4 @@ class Game {
     }
 }
 
-window.addEventListener('DOMContentLoaded', () => new Game());
+window.Game = Game;

--- a/index.html
+++ b/index.html
@@ -7,7 +7,45 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <canvas id="gameCanvas" width="800" height="600"></canvas>
+    <div id="splash">
+        <img src="assets/the-explorer-splash.png" alt="The Explorer" />
+    </div>
+    <div id="menu" class="hidden">
+        <h1>The Explorer</h1>
+        <p>Use the <strong>Arrow Keys</strong> to move.</p>
+        <p>Press <strong>Enter</strong> to begin your adventure.</p>
+    </div>
+    <canvas id="gameCanvas" width="800" height="600" class="hidden"></canvas>
     <script src="game.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const splash = document.getElementById('splash');
+            const menu = document.getElementById('menu');
+            const canvas = document.getElementById('gameCanvas');
+
+            let splashHandled = false;
+            const hideSplash = () => {
+                if (splashHandled) return;
+                splashHandled = true;
+                splash.classList.add('hidden');
+                menu.classList.remove('hidden');
+            };
+
+            const splashTimeout = setTimeout(hideSplash, 3000);
+            window.addEventListener('keydown', () => {
+                clearTimeout(splashTimeout);
+                hideSplash();
+            }, { once: true });
+
+            window.addEventListener('keydown', function startGame(e) {
+                if (e.key === 'Enter' && !menu.classList.contains('hidden')) {
+                    menu.classList.add('hidden');
+                    canvas.classList.remove('hidden');
+                    new Game();
+                    window.removeEventListener('keydown', startGame);
+                }
+            });
+        });
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,26 @@ body {
     height: 100vh;
 }
 
+#splash, #menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background: #000;
+    color: #fff;
+    transition: opacity 0.5s ease;
+}
+
+.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
 #gameCanvas {
     border: 1px solid #555;
     background: #000;


### PR DESCRIPTION
## Summary
- add splash and menu overlays and initialization script
- fade splash into instructions after keypress or 3s
- start the game when Enter is pressed
- expose Game class instead of auto-starting

## Testing
- `npm test` *(fails: could not find package.json)*